### PR TITLE
setup-db : Configuration initiale de la base de donnée Mysql

### DIFF
--- a/src/main/java/fr/jerem/chaotop_backend/model/Message.java
+++ b/src/main/java/fr/jerem/chaotop_backend/model/Message.java
@@ -1,0 +1,45 @@
+package fr.jerem.chaotop_backend.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "MESSAGES")
+public class Message {
+
+    @Id
+    @Column(name = "id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rental_id", nullable = false)
+    private Rental rental;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "message", length = 2000)
+    private String message;
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/fr/jerem/chaotop_backend/model/Rental.java
+++ b/src/main/java/fr/jerem/chaotop_backend/model/Rental.java
@@ -1,0 +1,55 @@
+package fr.jerem.chaotop_backend.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "RENTALS")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Rental {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Integer id;
+
+    @Column(name = "name", length = 255)
+    private String name;
+
+    @Column(name = "surface")
+    private double surface;
+
+    @Column(name = "price", precision = 10, scale = 2, nullable = false, columnDefinition = "NUMERIC")
+    private BigDecimal price;
+
+    @Column(name = "picture", length = 255)
+    private String picture;
+
+    @Column(name = "description", length = 2000)
+    private String description;
+
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "owner_id", nullable = false) // Définir la clé étrangère vers USERS
+    private User owner;
+
+    @Column(name = "created_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", columnDefinition = "TIMESTAMP")
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/fr/jerem/chaotop_backend/model/User.java
+++ b/src/main/java/fr/jerem/chaotop_backend/model/User.java
@@ -1,0 +1,36 @@
+package fr.jerem.chaotop_backend.model;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(name = "users",    uniqueConstraints = @UniqueConstraint(columnNames = "email")) // Crée l'index unique sur `email`)
+@Getter
+@Setter
+@NoArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    private String email;
+    private String name;
+    private String password;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/fr/jerem/chaotop_backend/repository/UserRepository.java
+++ b/src/main/java/fr/jerem/chaotop_backend/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package fr.jerem.chaotop_backend.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import fr.jerem.chaotop_backend.model.User;
+
+public interface UserRepository extends JpaRepository<User, Integer> {
+    public User findByUsername(String username);
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,10 @@
 spring.application.name=chaotop-backend
 
+spring.datasource.url=jdbc:mysql://localhost:3306/chaotop
+spring.datasource.username=chaotop
+spring.datasource.password=chaotop
+
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.datasource.driver-class-name=com.mysql.jdbc.Driver
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true


### PR DESCRIPTION
 - configuration datasource au niveau de application.properties
 - configuration hibernate en create-drop pour les tests
 - définition des models Message, User et Rental pour représenter respectivement les tables messages, users et rentals
 - utilisationdes anotations JPA ManyToOne et JoinColumn pour la définition des clés étrangères vers rental et user
 - définition de l'interface UserRepository avec une méthode custom