### PR TITLE
feature/update-docker: Mise à jour de la partie Docker

### DIFF
--- a/.sample-env-chaotop
+++ b/.sample-env-chaotop
@@ -1,5 +1,5 @@
-CHAOTOP_URL=jdbc:mysql://mysql:3306/chaotop
-CHAOTOP_USER=chaotop
+CHAOTOP_DBURL=jdbc:mysql://mysql:3306/chaotop
+CHAOTOP_DBUSER=chaotop
 CHAOTOP_DBKEY=chaotopdbuserpassword
 
 

--- a/README.md
+++ b/README.md
@@ -200,10 +200,11 @@ MYSQL_PASSWORD=chaotopdbuserpassword
 
 Deux options possibles:
 
-- un fichier Dockerfile avec COPY du jar de l'application
-- un fichier Dockerfile complet permettant de faire le build complet à partir des sources du projet
+- un fichier Dockerfile minimal si vous voulez fournir le jar de l'application
+- un fichier Dockerfile complet permettant de faire le build à partir des sources du projet
 
 ### Option 1 : Simple Dockerfile avec COPY du jar de l'application
+Si vous avez déjà construit l'artefact de l'application et que vous souhaitez l'utiliser, remplacer le contenu du fichier Dockerfile par :
 
 ```bash
 FROM openjdk:17-jdk-alpine
@@ -214,37 +215,7 @@ ENTRYPOINT ["java", "-jar", "/chaotop-backend.jar"]
 
 ### Option 2 : Dockerfile complet permettant de faire le build à partir des sources du projet
 
-Le fichier Dockerfile est déjà présent à la racine de l'application.
-
-```bash
-# Maven image used to build
-FROM maven:latest AS build
-
-# Workdir
-WORKDIR /app
-
-# Copy pom.xml and run mvn dependency
-COPY pom.xml ./
-RUN mvn dependency:go-offline
-
-# Copy source files
-COPY src ./src
-
-# Build the app with DskipTests to ovoid jdbc connection errors
-RUN mvn clean install -DskipTests
-
-# Build the final image with openjdk image
-FROM openjdk:17-jdk-alpine
-
-# workdir
-WORKDIR /app
-
-# Copy the previous generated jar file
-COPY --from=build /app/target/chaotop-backend-0.0.1-SNAPSHOT.jar chaotop-backend.jar
-
-# Entrypoint
-ENTRYPOINT ["java", "-jar", "/app/chaotop-backend.jar"]
-```
+Sinon un fichier Dockerfile est déjà présent à la racine de l'application et permet de faire le build des source à l'aide d'une image maven et de construire ensuite une image pour l'application API.
 
 ## docker-compose.yml : Utilisez ensuite le fichier docker-compose.yml fourni
 
@@ -262,6 +233,7 @@ docker compose up -d
 docker compose ps
 docker compose logs -f --tail=10
 ```
+
 
 # Accéder et utiliser l'api
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,14 @@ services:
     container_name: chaotop-api
     restart: unless-stopped
     build: .
-    ports: 
+    ports:
       - "8080:8080"
-    depends_on: 
+    depends_on:
       - mysql
     env_file:
       - .env-chaotop
+    networks:
+      - chaotop_network
 
   mysql:
     image: mysql:8.0
@@ -20,13 +22,9 @@ services:
       - .env-mysql
     volumes:
       - mysql_data:/var/lib/mysql
+    networks:
+      - chaotop_network
 
-  test:
-    image: debian
-    container_name: chaotop-test
-    stdin_open: true
-    tty: true
-    
 
 volumes:
   mysql_data:


### PR DESCRIPTION
 - Mise à jour des noms de variables erronnées CHAOTOP_DBUSER et CHAOTOP_DBURL.
 - Simplification du README concernant la partie docker
 - Correction coquille chaotop_network non utilisé dans le fichier compose